### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Glean
+[![smithery badge](https://smithery.ai/badge/@longyi1207/glean)](https://smithery.ai/server/@longyi1207/glean)
 
 An MCP server implementation that integrates the Glean API, providing the Search and Chat functions.
 
@@ -35,6 +36,14 @@ Then add this to your `claude_desktop_config.json`:
     }
   }
 }
+```
+
+### Installing via Smithery
+
+To install Glean for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@longyi1207/glean):
+
+```bash
+npx -y @smithery/cli install @longyi1207/glean --client claude
 ```
 
 ## License

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - gleanApiKey
+      - gleanDomain
+    properties:
+      gleanApiKey:
+        type: string
+        description: The API key for the Glean server.
+      gleanDomain:
+        type: string
+        description: The domain for the Glean server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'node', args: ['dist/index.js'], env: { GLEAN_API_KEY: config.gleanApiKey, GLEAN_DOMAIN: config.gleanDomain } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@longyi1207/glean?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂